### PR TITLE
Add archiver

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -4,10 +4,10 @@
 
 require 'scraperwiki'
 require 'nokogiri'
-require 'open-uri'
-
-require 'open-uri/cached'
-OpenURI::Cache.cache_path = '.cache'
+#require 'open-uri'
+#require 'open-uri/cached'
+#OpenURI::Cache.cache_path = '.cache'
+require 'scraped_page_archive/open-uri'
 
 def noko_for(url)
   Nokogiri::HTML(open(url).read)

--- a/scraper.rb
+++ b/scraper.rb
@@ -4,9 +4,9 @@
 
 require 'scraperwiki'
 require 'nokogiri'
-#require 'open-uri'
-#require 'open-uri/cached'
-#OpenURI::Cache.cache_path = '.cache'
+
+# require 'open-uri/cached'
+# OpenURI::Cache.cache_path = '.cache'
 require 'scraped_page_archive/open-uri'
 
 def noko_for(url)


### PR DESCRIPTION
## What does this do?

Uses scraped-page-archive to archive all pages scraped.

## Why is this needed?

Elections happened recently ([2016-11-20](https://en.wikipedia.org/wiki/Sammarinese_general_election,_2016)), and it's likely that the data on the official site will disappear, meaning any data we're not already picking up will be lost. Archiving it now gives us the chance to go back and re-scrape later even if it disappears.

## Relevant Issue(s):

https://github.com/everypolitician/everypolitician-data/issues/20544

## Checklists:

Scraper page
------------

* [ ] scraper is on Morph.io under the "everypolitician-scrapers" group <https://morph.io/everypolitician-scrapers/san_marino_council>  <br> _actually: currently it isn't, it's in `tmtmtmtm` at the moment_
* [x] scraper's GitHub "Website" link points at morph.io page <https://github.com/tmtmtmtm/san_marino_council> <br> _note:_ not `everypolitician-scrapers` *yet*
* [x] scraper is set to auto-run <https://morph.io/everypolitician-scrapers/san_marino_council/settings>
* [ ] ~scraper has webhook set _(usually only set on Wikidata person-data scrapers)_~ Not needed
* [ ] scraper is configured for archiving _(unless source doesn't require that)_ @tmtmtmtm please add GitHub auth ENV settings for https://morph.io/tmtmtmtm/san_marino_council thx!

Scraper is not under EP-scrapers account on morph.

## Add archiving

* [x] we are using at least version 0.5 of scraped-page-archive-gem
* [x] scraper uses scraped-page-archive gem directly or via a suitable strategy
* [ ] MORPH_SCRAPER_CACHE_GITHUB_REPO_URL is configured
* [x] pages are being archived in new branch of correct scraper repo <https://github.com/everypolitician-scrapers/san_marino_council/tree/scraped-pages-archive> <br> ~actually not *all* of them yet~ (yes they are! 18-Nov-16 DW)

The scraper was run locally to archive the current version of the page.
